### PR TITLE
Introduce parallel

### DIFF
--- a/capistrano.gemspec
+++ b/capistrano.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'sshkit', '>= 1.7.1'
   gem.add_dependency 'rake', '>= 10.0.0'
   gem.add_dependency 'i18n'
+  gem.add_dependency 'parallel', '>= 1.6.1'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'mocha'

--- a/lib/capistrano/all.rb
+++ b/lib/capistrano/all.rb
@@ -12,6 +12,7 @@ require 'capistrano/dsl'
 require 'capistrano/application'
 require 'capistrano/configuration'
 
+require 'parallel'
 module Capistrano
 
 end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -100,7 +100,7 @@ namespace :deploy do
       on release_roles :all do
         execute :mkdir, '-p', linked_dir_parents(release_path)
 
-        fetch(:linked_dirs).each do |dir|
+        Parallel.each(fetch(:linked_dirs), in_threads: fetch(:linked_dirs).count) do |dir|
           target = release_path.join(dir)
           source = shared_path.join(dir)
           unless test "[ -L #{target} ]"


### PR DESCRIPTION
### Problem

The execution of :symlink:linked_dirs takes around 18 seconds, 
under `linked_dirs = %w{bin log tmp/pids tmp/cache tmp/sockets tmp/backup vendor/bundle public/system public/assets}` .

Because there is 3 ssh remote execution for each linked_dir. 
(1 ssh remote execution takes around 1 sec)

```
unless test "[ -L #{target} ]"
            if test "[ -d #{target} ]"
              execute :rm, '-rf', target
            end
            execute :ln, '-s', source, target
```
### Changes

I introduced `parallel` to execute each `linked_dir` process.
After that, the whole process takes about 9 sec.
